### PR TITLE
Use string concat for lumbar paths. Fixes #7.

### DIFF
--- a/tasks/generate.js
+++ b/tasks/generate.js
@@ -55,13 +55,13 @@ ThoraxGenerator.prototype.module = function(name) {
 };
 
 ThoraxGenerator.prototype.spec = function(name) {
-  this.write(path.join(this.paths.specs, name + '.' + this.language), this.render('spec.handlebars', {
+  this.write((this.paths.specs + '/' + name + '.' + this.language), this.render('spec.handlebars', {
     name: name
   }));
 };
 
 ThoraxGenerator.prototype.style = function(name, moduleName) {
-  var target = path.join(this.paths.stylesheets, name + '.css'),
+  var target = this.paths.stylesheets + '/' + name + '.css',
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName);
   this.write(target, '');
@@ -69,7 +69,7 @@ ThoraxGenerator.prototype.style = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype.router = function(name, moduleName) {
-  var target = path.join(this.paths.routers, name + '.' + this.language),
+  var target = this.paths.routers + '/' + name + '.' + this.language,
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName, true);
   this.write(target, this.render('router.handlebars', {
@@ -79,7 +79,7 @@ ThoraxGenerator.prototype.router = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype.view = function(name, moduleName) {
-  var target = path.join(this.paths.views, name + '.' + this.language),
+  var target = this.paths.views + '/' + name + '.' + this.language,
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName);
   addScript.call(this, moduleName, target);
@@ -90,7 +90,7 @@ ThoraxGenerator.prototype.view = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype['collection-view'] = function(name, moduleName) {
-  var target = path.join(this.paths.views, name + '.' + this.language),
+  var target = this.paths.views + '/' + name + '.' + this.language,
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName);
   addScript.call(this, moduleName, target);
@@ -103,7 +103,7 @@ ThoraxGenerator.prototype['collection-view'] = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype.collection = function(name, moduleName) {
-  var target = path.join(this.paths.collections, name + '.' + this.language),
+  var target = this.paths.collections + '/' + name + '.' + this.language,
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName);
   addScript.call(this, moduleName, target);
@@ -113,7 +113,7 @@ ThoraxGenerator.prototype.collection = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype.model = function(name, moduleName) {
-  var target = path.join(this.paths.models, name + '.' + this.language),
+  var target = this.paths.models + '/' + name + '.' + this.language,
       moduleName = moduleName || name.split('/').shift();
   ensureModule.call(this, moduleName);
   addScript.call(this, moduleName, target);
@@ -123,7 +123,7 @@ ThoraxGenerator.prototype.model = function(name, moduleName) {
 };
 
 ThoraxGenerator.prototype.template = function(name) {
-  var target = path.join(this.paths.templates, name + '.handlebars');
+  var target = this.paths.templates + '/' + name + '.handlebars';
   this.write(target, '');
 };
 


### PR DESCRIPTION
The generate task currently uses [path.join()](http://nodejs.org/api/path.html#path_path_join_path1_path2) to construct paths for lumbar.json. On Windows, `path.join()` uses backslashes instead of forward slashes, which is the opposite of what we want for lumbar (see #7). 

We can avoid this by replacing path.join() with string concatenation, as the generate task isn't actually using any of the main benefits of path.join() (accepting `n` arguments, normalizing extra slashes). 

String concat doesn't look as nice, but will work better. Could also remove trailing slashes on paths if we need to, but it didn't seem necessary.
