### PR TITLE
Fixed grunt generate command, module defaults to base if not specified

### DIFF
--- a/tasks/generate.js
+++ b/tasks/generate.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
       if (!path) {
         throw new Error('Path argument required to generate:' + action);
       }
+      if(!moduleName && path.indexOf('/') === -1) moduleName = "base";
       var generator = new ThoraxGenerator();
       ThoraxGenerator.currentAction = action;
       generator[action].apply(generator, [path, moduleName]);


### PR DESCRIPTION
Fixed grunt generate issue where a module was being created with the filename if a module was not specified. Now leaving off the module name defaults to base module.
