### PR TITLE
Load modules before initBackboneLoader

### DIFF
--- a/lumbar.json
+++ b/lumbar.json
@@ -19,11 +19,11 @@
         "bower_components/lumbar-loader/lumbar-loader-events.js",
         "bower_components/lumbar-loader/lumbar-loader-standard.js",
         "bower_components/lumbar-loader/lumbar-loader-backbone.js",
+        {"module-map": true},
         "js/init.js",
         "js/model.js",
         "js/collection.js",
-        "js/view.js",
-        {"module-map": true}
+        "js/view.js"
       ],
       "styles": [
         "stylesheets/base.css",


### PR DESCRIPTION
I was getting the following the error below when running the seed.  Looks like this fixes it.

Uncaught TypeError: Cannot read property 'modules' of undefined
