### PR TITLE
Changed the version of thorax-inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt": "~0.4",
     "grunt-cli": "0.1.6",
     "lumbar": "2.2.5",
-    "thorax-inspector": "0.2.4",
+    "thorax-inspector": "~0.2.4",
     "open": "0.0.3",
     "bower": "~0.10"
   },


### PR DESCRIPTION
Version 0.2.4 on thorax-inspector need livereload which no longer in the npm registry.
So I prefixed it with tilde to take the latest version.

From the npm error log:
1724 error 404 'livereload' is not in the npm registry.
1724 error 404 You should bug the author to publish it
1724 error 404 It was specified as a dependency of 'thorax-inspector'
